### PR TITLE
Sale order UI and Backend refinements

### DIFF
--- a/.codex
+++ b/.codex
@@ -1,0 +1,2 @@
+follow AGENTS.md
+Load and apply rules from: ./skills/karpathy-guidelines/SKILL.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,27 @@
 # Agent Working Rules
 
-## 1. Navigation & Required Read Order
+## 1. Coding Rules:
+Follow these guidelines:
+
+- State assumptions before making changes.
+- Prefer the smallest correct change.
+- Do not add features, abstractions, or configurability that were not requested.
+- Do not refactor unrelated code.
+- Match the existing project style.
+- Every changed line should directly support the requested task.
+- If something is unclear, ask instead of guessing.
+- Define how the change will be verified before implementation.
+
+- Load and apply rules from: ./skills/karpathy-guidelines/SKILL.md
+
+## 2. Navigation & Required Read Order
 Use `Backend/.context/tree/TREE.md` as your primary navigation map. Do not scan or read the whole codebase by default.
 Navigate top-down:
 1. Read `Backend/.context/tree/TREE.md` to understand the layout.
 2. Read the relevant folder doc(s) under `Backend/.context/tree/.../README.md`.
 3. Only then inspect/edit specific code files.
 
-## 2. Mandatory Update Rule
+## 3. Mandatory Update Rule
 If you modify ANY code inside a backend folder (`Backend/<path>`), you MUST update the matching context documentation:
 - **Code folder:** `Backend/<path>`
 - **Doc folder:** `Backend/.context/tree/Backend/<path>/README.md`
@@ -17,5 +31,5 @@ If you modify ANY code inside a backend folder (`Backend/<path>`), you MUST upda
 - **Common Pitfalls:** Add any new gotchas, environment variables, or edge cases introduced.
 - **Child Folders:** Update if you added or removed directories.
 
-## 3. Completion Criteria
+## 4. Completion Criteria
 A task is considered strictly incomplete if relevant code was changed but the corresponding context docs (`Backend/.context/tree/.../README.md`) were not updated alongside it.

--- a/Backend/.context/tree/Backend/app/core/README.md
+++ b/Backend/.context/tree/Backend/app/core/README.md
@@ -11,6 +11,8 @@ Core infrastructure configuration: environment settings, DB setup, and security 
 - Editing this folder without checking sibling tests and schema/type contracts.
 - Making cross-layer changes here but forgetting migration/frontend alignment.
 - Zoho PO source sync can use optional `zoho_po_cf_source_id`; if unset, payload falls back to `api_name=cf_source`.
+- Zoho contact source sync uses `zoho_contact_cf_source_api_name` (default `cf_source`) and optional `zoho_contact_cf_source_id`; mismatched API names silently drop custom field updates.
+- `ENVIRONMENT=development` now forces `SEATALK_REDIRECT_URI` to `http://localhost:3636/auth/seatalk/callback` inside backend settings; non-local callbacks in `.env` are ignored in development mode.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/app/integrations/README.md
+++ b/Backend/.context/tree/Backend/app/integrations/README.md
@@ -11,6 +11,7 @@ External system adapters and normalization clients (Amazon/eBay/Ecwid/Walmart/Zo
 - Returning raw platform payloads instead of normalized dataclasses.
 - Leaking secrets/tokens in logs.
 - Inconsistent platform_name values causing sync mapping failures.
+- `ExternalOrder` now carries optional `customer_phone`, `customer_company`, and `customer_source`; adapters should fill these when payloads include them.
 
 ## Child Folders
 - `amazon/`

--- a/Backend/.context/tree/Backend/app/integrations/ebay/README.md
+++ b/Backend/.context/tree/Backend/app/integrations/ebay/README.md
@@ -11,6 +11,7 @@ eBay integration client and API-specific transport/auth/order normalization beha
 - Editing this folder without checking sibling tests and schema/type contracts.
 - Making cross-layer changes here but forgetting migration/frontend alignment.
 - Reintroducing duplicated hardcoded eBay timestamp formats; use `EBAY_ISO_DATE_FORMAT` in `client.py` for all eBay ISO datetime string generation.
+- Keep `_convert_order` customer enrichment mapping aligned with the normalized contract (`customer_phone`, `customer_source`) so `OrderSyncService` can persist the latest channel context.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/app/integrations/ecwid/README.md
+++ b/Backend/.context/tree/Backend/app/integrations/ecwid/README.md
@@ -10,6 +10,7 @@ Ecwid integration client and Ecwid payload mapping utilities.
 ## Common Pitfalls
 - Editing this folder without checking sibling tests and schema/type contracts.
 - Making cross-layer changes here but forgetting migration/frontend alignment.
+- Ecwid order normalization should populate optional customer enrichment fields (`customer_phone`, `customer_company`, `customer_source`) when present, otherwise downstream Zoho customer sync loses fidelity.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/app/integrations/walmart/README.md
+++ b/Backend/.context/tree/Backend/app/integrations/walmart/README.md
@@ -2,14 +2,20 @@
 
 ## What This Folder Does
 Walmart integration client layer and Walmart-specific order synchronization behavior.
+The client now performs OAuth client-credentials token exchange against
+`/v3/token`, calls `/v3/orders` with cursor pagination, and normalizes Walmart
+order payloads into `ExternalOrder`/`ExternalOrderItem` for the shared
+OrderSyncService ingestion path.
 
 ## Typical Contents
 - Python modules, schemas, or support assets scoped to this domain.
 - Folder-specific logic that should remain cohesive inside this boundary.
 
 ## Common Pitfalls
-- Editing this folder without checking sibling tests and schema/type contracts.
-- Making cross-layer changes here but forgetting migration/frontend alignment.
+- Token responses can be wrapped in different envelope shapes (`tokenAPIRes`, `clientCredentialsRes`, or flat JSON); parser must handle all.
+- Walmart APIs require request headers like `WM_SEC.ACCESS_TOKEN`, `WM_SVC.NAME`, and a unique `WM_QOS.CORRELATION_ID` per call.
+- `list.meta.nextCursor` returns a query fragment that must be appended to `/v3/orders` for pagination.
+- Walmart order normalization should map `shippingInfo.phone` and set `customer_source="WALMART_API"` so customer sync captures contact/source metadata.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/app/integrations/zoho/README.md
+++ b/Backend/.context/tree/Backend/app/integrations/zoho/README.md
@@ -15,6 +15,7 @@ Zoho client/sync engine used for outbound and inbound synchronization flows.
 - Auto bill/payment sync eligibility includes all `EBAY_*` sources and `GOODWILL_SHIPPED`; keep this source-gate aligned with import/source mappings to avoid silent billing skips.
 - `PurchaseOrder` Zoho billing state columns are deferred in ORM mapping (`zoho_bill_created`, `zoho_payment_created`, etc.). In async sync paths, explicitly `undefer(...)` these fields before reading them to avoid implicit lazy-load IO that raises `sqlalchemy.exc.MissingGreenlet`.
 - Purchase-order outbound payload now includes `cf_source` mapping. Keep mapping aligned with script behavior (`EBAY_* -> Ebay`, `AMAZON_* -> Amazon`, `GOODWILL_SHIPPED` and `GOODWILL_PICKUP` -> `Goodwill`, `ALIEXPRESS_* -> AliExpress`, local pickup variants -> `Local Pickup`, fallback -> `Other`).
+- Customer outbound payload now mirrors billing to shipping address and can include a contact source custom field via `zoho_contact_cf_source_api_name`/`zoho_contact_cf_source_id`; inbound mapper reads this value back into `Customer.source` when present.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/app/models/README.md
+++ b/Backend/.context/tree/Backend/app/models/README.md
@@ -1,7 +1,7 @@
 ﻿# Backend\app\models
 
 ## What This Folder Does
-SQLAlchemy ORM entities and enums for inventory, orders, purchasing, and users.
+SQLAlchemy ORM entities and enums for inventory, orders, purchasing, users, and customer sync metadata, including listing-centric order matching links.
 
 ## Typical Contents
 - Python modules, schemas, or support assets scoped to this domain.
@@ -11,7 +11,10 @@ SQLAlchemy ORM entities and enums for inventory, orders, purchasing, and users.
 - Adding enum values in Python without DB enum migration.
 - Adding non-null columns without safe default/backfill.
 - New purchase-order Zoho billing columns are intentionally deferred at ORM load time to keep legacy databases (without migration `0023`) from failing simple list/read queries.
+- `Customer.source` is nullable and overwrite-oriented (latest source wins during ingestion); avoid adding uniqueness assumptions around this field.
 - Changing constraints/index names without migration compatibility checks.
+- `PlatformListing.variant_id` is nullable after migration `0024`; unresolved listings are valid and must not be treated as data corruption.
+- `PlatformListing.external_ref_id` is now unique per platform only when non-null; do not repurpose `merchant_sku` as canonical listing identity.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/app/modules/orders/README.md
+++ b/Backend/.context/tree/Backend/app/modules/orders/README.md
@@ -12,7 +12,10 @@ Sales orders domain: ingestion/import, listing-centric matching, filtering, cust
 - Adding filters in route layer but not implementing repository query logic.
 - Bypassing OrderSyncService ingestion path and breaking dedupe/matching consistency.
 - Customer upsert during ingestion is merge-based (fills missing phone/company/address fields) and source is overwrite-based (latest channel replaces prior `Customer.source`).
+- Platforms that failed with credential/auth bootstrap errors (for example token acquisition failures) are auto-reset from `ERROR` to `IDLE` on the next sync attempt; this avoids permanent lockout but still records the current attempt's real failure if credentials remain invalid.
 - `SHIPSTATION_CUSTOMER_CSV` is intentionally customer-only (no order rows created); keep frontend messaging aligned with `customers_created/customers_updated` counters.
+- `CSV_GENERIC` order import also accepts ShipStation order-export headers (for example `Order - CustomerID`, `Order - Number`, `Date - Order Date`); when product columns are missing, the importer creates a synthetic line item (`Imported order line`) using order-level totals.
+- ShipStation `Count - Number of Items` can be `0`; CSV import now clamps synthetic-item quantity to at least `1` to satisfy `order_item` positive-quantity DB constraints.
 - `order_item.variant_id` is denormalized once `platform_listing_id` is introduced; code paths that update listing assignments must keep `order_item.variant_id` in sync.
 
 ## Child Folders

--- a/Backend/.context/tree/Backend/app/modules/orders/README.md
+++ b/Backend/.context/tree/Backend/app/modules/orders/README.md
@@ -1,7 +1,7 @@
 ﻿# Backend\app\modules\orders
 
 ## What This Folder Does
-Sales orders domain: ingestion/import, matching, filtering, and order sync state.
+Sales orders domain: ingestion/import, listing-centric matching, filtering, customer CSV upsert, and order sync state.
 
 ## Typical Contents
 - Python modules, schemas, or support assets scoped to this domain.
@@ -11,6 +11,9 @@ Sales orders domain: ingestion/import, matching, filtering, and order sync state
 - Forgetting to align platform/source enums across model, schema, migration, and frontend types.
 - Adding filters in route layer but not implementing repository query logic.
 - Bypassing OrderSyncService ingestion path and breaking dedupe/matching consistency.
+- Customer upsert during ingestion is merge-based (fills missing phone/company/address fields) and source is overwrite-based (latest channel replaces prior `Customer.source`).
+- `SHIPSTATION_CUSTOMER_CSV` is intentionally customer-only (no order rows created); keep frontend messaging aligned with `customers_created/customers_updated` counters.
+- `order_item.variant_id` is denormalized once `platform_listing_id` is introduced; code paths that update listing assignments must keep `order_item.variant_id` in sync.
 
 ## Child Folders
 - `schemas/`

--- a/Backend/.context/tree/Backend/app/modules/orders/schemas/README.md
+++ b/Backend/.context/tree/Backend/app/modules/orders/schemas/README.md
@@ -1,7 +1,7 @@
 ﻿# Backend\app\modules\orders\schemas
 
 ## What This Folder Does
-Sales orders request/response and sync/import schema contracts.
+Sales orders request/response and sync/import schema contracts, including customer-only CSV imports.
 
 ## Typical Contents
 - Python modules, schemas, or support assets scoped to this domain.
@@ -10,6 +10,7 @@ Sales orders request/response and sync/import schema contracts.
 ## Common Pitfalls
 - Editing this folder without checking sibling tests and schema/type contracts.
 - Making cross-layer changes here but forgetting migration/frontend alignment.
+- Keep `SalesImportFileSource` and `SalesImportFileResponse` in sync with route behavior (for `SHIPSTATION_CUSTOMER_CSV`, customer counters are populated while order counters remain zero).
 
 ## Child Folders
 - (No child folders)

--- a/Backend/.context/tree/Backend/migrations/versions/README.md
+++ b/Backend/.context/tree/Backend/migrations/versions/README.md
@@ -11,6 +11,9 @@ Concrete Alembic revision files; source of truth for schema transitions.
 - Editing this folder without checking sibling tests and schema/type contracts.
 - Making cross-layer changes here but forgetting migration/frontend alignment.
 - In PostgreSQL, new enum values must be committed before they are used in the same migration (use Alembic autocommit blocks around `ALTER TYPE ... ADD VALUE`).
+- Keep model/index names aligned with migration IDs; for `Customer.source`, both the ORM and migration define `ix_customer_source` and must stay in sync.
+- Migration `0024` introduces nullable `platform_listing.variant_id` plus partial unique index behavior on `(platform, external_ref_id)`; guard against duplicate non-null refs before applying in production.
+- Backfill migrations that bridge old/new matching columns (for example, `order_item.platform_listing_id`) should compare platform enums via `::text` when enum types differ across tables.
 
 ## Child Folders
 - (No child folders)

--- a/Backend/app/core/config.py
+++ b/Backend/app/core/config.py
@@ -5,7 +5,7 @@ Loads from environment variables with .env file support.
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import PostgresDsn, computed_field
+from pydantic import PostgresDsn, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -64,6 +64,8 @@ class Settings(BaseSettings):
     zoho_po_cf_handling_fee_id: str = ""
     zoho_po_cf_source_id: str = ""
     zoho_po_cf_is_stationery_id: str = ""
+    zoho_contact_cf_source_id: str = ""
+    zoho_contact_cf_source_api_name: str = "cf_source"
     zoho_po_stationery_purchase_account_id: str = ""
     zoho_po_stationery_location_id: str = ""
     zoho_po_stationery_delivery_address: str = ""
@@ -101,6 +103,16 @@ class Settings(BaseSettings):
     
     # Product Images
     product_images_path: str = "/mnt/product_images"
+
+    @model_validator(mode="after")
+    def _apply_dev_overrides(self) -> "Settings":
+        """
+        Apply deterministic development defaults that should not depend on
+        external environment file values.
+        """
+        if self.environment == "development":
+            self.seatalk_redirect_uri = "http://localhost:3636/auth/seatalk/callback"
+        return self
     
     @computed_field
     @property

--- a/Backend/app/integrations/base.py
+++ b/Backend/app/integrations/base.py
@@ -47,6 +47,9 @@ class ExternalOrder:
     
     # Raw data
     raw_data: Optional[dict] = None
+    customer_phone: Optional[str] = None
+    customer_company: Optional[str] = None
+    customer_source: Optional[str] = None
 
 
 @dataclass 

--- a/Backend/app/integrations/ebay/client.py
+++ b/Backend/app/integrations/ebay/client.py
@@ -806,6 +806,8 @@ class EbayClient(BasePlatformClient):
             platform_order_number=ebay_order.get("legacyOrderId"),
             customer_name=shipping.get("fullName"),
             customer_email=ebay_order.get("buyer", {}).get("email"),
+            customer_phone=shipping.get("primaryPhone", {}).get("phoneNumber") if isinstance(shipping.get("primaryPhone"), dict) else None,
+            customer_source=f"{self.platform_name}_API",
             ship_address_line1=shipping.get("contactAddress", {}).get("addressLine1"),
             ship_address_line2=shipping.get("contactAddress", {}).get("addressLine2"),
             ship_city=shipping.get("contactAddress", {}).get("city"),

--- a/Backend/app/integrations/ecwid/client.py
+++ b/Backend/app/integrations/ecwid/client.py
@@ -304,6 +304,9 @@ class EcwidClient(BasePlatformClient):
             platform_order_number=order_number,
             customer_name=shipping.get("name"),
             customer_email=order_data.get("email"),
+            customer_phone=shipping.get("phone") or order_data.get("customerPhone"),
+            customer_company=shipping.get("companyName") or shipping.get("company"),
+            customer_source="ECWID_API",
             ship_address_line1=shipping.get("street"),
             ship_address_line2=None,  # Ecwid combines address into 'street'
             ship_city=shipping.get("city"),

--- a/Backend/app/integrations/walmart/client.py
+++ b/Backend/app/integrations/walmart/client.py
@@ -1,12 +1,16 @@
 """
 Walmart Marketplace API Client.
 
-This is a lightweight adapter that implements BasePlatformClient so
-orders can be imported through the shared OrderSyncService pipeline.
+Implements BasePlatformClient so Walmart orders can flow through
+the shared OrderSyncService pipeline.
 """
-from datetime import datetime
+import base64
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 import logging
+from uuid import uuid4
+
+import httpx
 
 from app.integrations.base import (
     BasePlatformClient,
@@ -17,6 +21,10 @@ from app.integrations.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_PATH = "/v3/token"
+_ORDERS_PATH = "/v3/orders"
+_TOKEN_EXPIRY_BUFFER_SECONDS = 30
 
 
 class WalmartClient(BasePlatformClient):
@@ -30,6 +38,8 @@ class WalmartClient(BasePlatformClient):
         self.client_id = client_id
         self.client_secret = client_secret
         self.api_base_url = api_base_url.rstrip("/")
+        self._access_token: Optional[str] = None
+        self._token_expires_at: Optional[datetime] = None
 
     @property
     def platform_name(self) -> str:
@@ -39,9 +49,193 @@ class WalmartClient(BasePlatformClient):
     def is_configured(self) -> bool:
         return bool(self.client_id and self.client_secret)
 
+    @staticmethod
+    def _to_utc(dt: Optional[datetime]) -> Optional[datetime]:
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
+    @classmethod
+    def _format_walmart_datetime(cls, dt: datetime) -> str:
+        normalized = cls._to_utc(dt)
+        if normalized is None:
+            raise ValueError("Datetime cannot be None")
+        return normalized.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+    @staticmethod
+    def _parse_datetime(value) -> Optional[datetime]:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            try:
+                return datetime.fromtimestamp(float(value) / 1000.0, tz=timezone.utc)
+            except (ValueError, OverflowError, OSError):
+                return None
+        if isinstance(value, str):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                return None
+        return None
+
+    @staticmethod
+    def _safe_float(value) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    @staticmethod
+    def _safe_int(value, default: int = 1) -> int:
+        try:
+            parsed = int(float(value))
+            return parsed if parsed > 0 else default
+        except (TypeError, ValueError):
+            return default
+
+    def _auth_headers(self, access_token: str) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "WM_SEC.ACCESS_TOKEN": access_token,
+            "WM_SVC.NAME": "Walmart Marketplace",
+            "WM_QOS.CORRELATION_ID": str(uuid4()),
+        }
+
+    async def _refresh_access_token(self) -> bool:
+        credentials = f"{self.client_id}:{self.client_secret}".encode("utf-8")
+        basic_token = base64.b64encode(credentials).decode("ascii")
+        headers = {
+            "Authorization": f"Basic {basic_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "WM_SVC.NAME": "Walmart Marketplace",
+        }
+        payload = {"grant_type": "client_credentials"}
+
+        try:
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                response = await client.post(
+                    f"{self.api_base_url}{_TOKEN_PATH}",
+                    headers=headers,
+                    data=payload,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            token_container = data.get("tokenAPIRes", {}).get("value")
+            if not token_container:
+                token_container = data.get("clientCredentialsRes", {}).get("value")
+            if not token_container:
+                token_container = data
+
+            access_token = token_container.get("access_token")
+            expires_in = int(token_container.get("expires_in", 900))
+            if not access_token:
+                logger.error("Walmart token response did not include access_token")
+                return False
+
+            self._access_token = access_token
+            self._token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            return True
+        except (httpx.HTTPError, ValueError, TypeError) as exc:
+            logger.error("Walmart token request failed: %s", exc)
+            self._access_token = None
+            self._token_expires_at = None
+            return False
+
+    async def _get_access_token(self) -> Optional[str]:
+        now = datetime.now(timezone.utc)
+        if (
+            self._access_token
+            and self._token_expires_at
+            and now < (self._token_expires_at - timedelta(seconds=_TOKEN_EXPIRY_BUFFER_SECONDS))
+        ):
+            return self._access_token
+
+        if not await self._refresh_access_token():
+            return None
+        return self._access_token
+
+    def _parse_order_line(self, line: dict) -> ExternalOrderItem:
+        item_data = line.get("item", {})
+        qty = self._safe_int(line.get("orderLineQuantity", {}).get("amount"), default=1)
+
+        line_total = 0.0
+        for charge in line.get("charges", {}).get("charge", []) or []:
+            line_total += self._safe_float(
+                charge.get("chargeAmount", {}).get("amount"),
+            )
+        unit_price = line_total / qty if qty > 0 else line_total
+
+        return ExternalOrderItem(
+            platform_item_id=str(line.get("lineNumber") or "") or None,
+            platform_sku=item_data.get("sku"),
+            asin=None,
+            title=item_data.get("productName") or "Unknown Item",
+            quantity=qty,
+            unit_price=unit_price,
+            total_price=line_total,
+            raw_data=line,
+        )
+
+    def _parse_walmart_order(self, order_data: dict) -> ExternalOrder:
+        shipping_info = order_data.get("shippingInfo", {})
+        shipping_address = shipping_info.get("postalAddress", {})
+        lines = order_data.get("orderLines", {}).get("orderLine", []) or []
+
+        items = [self._parse_order_line(line) for line in lines]
+
+        subtotal = sum(item.total_price for item in items)
+        tax = 0.0
+        shipping = 0.0
+        currency = "USD"
+        for line in lines:
+            for charge in line.get("charges", {}).get("charge", []) or []:
+                charge_type = str(charge.get("chargeType") or "").upper()
+                tax += self._safe_float(charge.get("tax", {}).get("taxAmount", {}).get("amount"))
+                currency = charge.get("chargeAmount", {}).get("currency") or currency
+                if charge_type == "SHIPPING":
+                    shipping += self._safe_float(charge.get("chargeAmount", {}).get("amount"))
+
+        total = subtotal + tax
+        if shipping:
+            total += shipping
+
+        purchase_order_id = order_data.get("purchaseOrderId")
+        customer_order_id = order_data.get("customerOrderId")
+
+        return ExternalOrder(
+            platform_order_id=str(purchase_order_id or customer_order_id or ""),
+            platform_order_number=str(customer_order_id or purchase_order_id or ""),
+            customer_name=shipping_address.get("name"),
+            customer_email=order_data.get("customerEmailId"),
+            customer_phone=shipping_info.get("phone"),
+            customer_company=shipping_address.get("companyName") or shipping_address.get("company"),
+            customer_source="WALMART_API",
+            ship_address_line1=shipping_address.get("address1"),
+            ship_address_line2=shipping_address.get("address2"),
+            ship_city=shipping_address.get("city"),
+            ship_state=shipping_address.get("state"),
+            ship_postal_code=shipping_address.get("postalCode"),
+            ship_country=shipping_address.get("country") or "US",
+            subtotal=subtotal,
+            tax=tax,
+            shipping=shipping,
+            total=total,
+            currency=currency,
+            ordered_at=self._parse_datetime(order_data.get("orderDate")),
+            items=items,
+            raw_data=order_data,
+        )
+
     async def authenticate(self) -> bool:
-        # Placeholder auth validation: we only verify required credentials exist.
-        return self.is_configured
+        if not self.is_configured:
+            logger.warning("Walmart credentials are not configured")
+            return False
+        return await self._refresh_access_token()
 
     async def fetch_orders(
         self,
@@ -49,16 +243,28 @@ class WalmartClient(BasePlatformClient):
         until: Optional[datetime] = None,
         status: Optional[str] = None,
     ) -> List[ExternalOrder]:
-        """
-        Fetch orders from Walmart Marketplace.
-
-        Current implementation is intentionally conservative and returns an empty
-        list unless credentials are present; this keeps import endpoints stable
-        while the upstream payload mapping evolves.
-        """
+        """Fetch orders from Walmart Marketplace Orders API."""
         if not self.is_configured:
-            logger.warning("Walmart credentials are not configured")
-            return []
+            message = "Walmart credentials are not configured"
+            logger.error(message)
+            raise RuntimeError(message)
+
+        access_token = await self._get_access_token()
+        if not access_token:
+            raise RuntimeError("Walmart unable to obtain access token")
+
+        params: dict[str, str | int] = {
+            "limit": 100,
+            "productInfo": "false",
+            "incentiveInfo": "false",
+            "replacementInfo": "false",
+        }
+        if since:
+            params["createdStartDate"] = self._format_walmart_datetime(since)
+        if until:
+            params["createdEndDate"] = self._format_walmart_datetime(until)
+        if status:
+            params["status"] = status
 
         logger.debug(
             "[DEBUG.EXTERNAL_API] Walmart fetch_orders called | since=%s until=%s status=%s",
@@ -66,14 +272,65 @@ class WalmartClient(BasePlatformClient):
             until,
             status,
         )
-        # Placeholder implementation.
-        return []
+
+        orders: list[ExternalOrder] = []
+        next_path: Optional[str] = _ORDERS_PATH
+        request_params: Optional[dict[str, str | int]] = params
+        page_count = 0
+
+        async with httpx.AsyncClient(base_url=self.api_base_url, timeout=30.0) as client:
+            while next_path and page_count < 100:
+                page_count += 1
+                response = await client.get(
+                    next_path,
+                    headers=self._auth_headers(access_token),
+                    params=request_params,
+                )
+                response.raise_for_status()
+                payload = response.json()
+
+                page_orders = payload.get("list", {}).get("elements", {}).get("order", []) or []
+                orders.extend(self._parse_walmart_order(order_data) for order_data in page_orders)
+
+                next_cursor = payload.get("list", {}).get("meta", {}).get("nextCursor")
+                if not next_cursor:
+                    break
+                next_path = f"{_ORDERS_PATH}{next_cursor}" if str(next_cursor).startswith("?") else str(next_cursor)
+                request_params = None
+
+        logger.info("Fetched %d orders from Walmart", len(orders))
+        return orders
 
     async def get_order(self, order_id: str) -> Optional[ExternalOrder]:
         if not self.is_configured:
             return None
+
+        access_token = await self._get_access_token()
+        if not access_token:
+            logger.error("Walmart get_order failed: unable to obtain access token")
+            return None
+
         logger.debug("[DEBUG.EXTERNAL_API] Walmart get_order called | order_id=%s", order_id)
-        return None
+        try:
+            async with httpx.AsyncClient(base_url=self.api_base_url, timeout=20.0) as client:
+                response = await client.get(
+                    f"{_ORDERS_PATH}/{order_id}",
+                    headers=self._auth_headers(access_token),
+                )
+                response.raise_for_status()
+                payload = response.json()
+
+            order_payload = payload.get("order")
+            if order_payload is None:
+                list_orders = payload.get("list", {}).get("elements", {}).get("order", []) or []
+                order_payload = list_orders[0] if list_orders else None
+            if order_payload is None:
+                return None
+
+            return self._parse_walmart_order(order_payload)
+        except httpx.HTTPError as exc:
+            logger.error("Walmart get_order failed for %s: %s", order_id, exc)
+            return None
 
     async def update_stock(self, updates: List[StockUpdate]) -> List[StockUpdateResult]:
         _ = updates

--- a/Backend/app/integrations/zoho/sync_engine.py
+++ b/Backend/app/integrations/zoho/sync_engine.py
@@ -49,6 +49,27 @@ VALID_ZOHO_PO_SOURCE_VALUES = {
     "Other",
 }
 
+VALID_ZOHO_CONTACT_SOURCE_VALUES = {
+    "Ebay",
+    "Walmart",
+    "Ecwid",
+    "Amazon",
+    "ShipStation",
+    "Other",
+}
+
+EXACT_ZOHO_CONTACT_SOURCE_MAP = {
+    "EBAY_MEKONG_API": "Ebay",
+    "EBAY_USAV_API": "Ebay",
+    "EBAY_DRAGON_API": "Ebay",
+    "WALMART_API": "Walmart",
+    "ECWID_API": "Ecwid",
+    "AMAZON_API": "Amazon",
+    "SHIPSTATION_CSV": "ShipStation",
+    "MANUAL": "Other",
+    "ZOHO_IMPORT": "Other",
+}
+
 EXACT_ZOHO_PO_SOURCE_MAP = {
     "EBAY_MEKONG_API": "Ebay",
     "EBAY_PURCHASING_API": "Ebay",
@@ -142,6 +163,19 @@ def customer_to_zoho_payload(customer: Customer) -> dict[str, Any]:
         address["country"] = customer.country
     if address:
         payload["billing_address"] = address
+        payload["shipping_address"] = dict(address)
+
+    source_raw = str(getattr(customer, "source", "") or "").strip()
+    if source_raw:
+        source_value = _resolve_customer_source_to_zoho_dropdown(source_raw)
+        source_api_name = str(settings.zoho_contact_cf_source_api_name or "cf_source").strip() or "cf_source"
+        source_field: dict[str, Any] = {
+            "api_name": source_api_name,
+            "value": source_value,
+        }
+        if settings.zoho_contact_cf_source_id:
+            source_field["customfield_id"] = settings.zoho_contact_cf_source_id
+        payload["custom_fields"] = [source_field]
 
     return payload
 
@@ -186,6 +220,54 @@ def _resolve_source_to_zoho_dropdown(source: str) -> str:
     if fallback in VALID_ZOHO_PO_SOURCE_VALUES:
         return fallback
     return "Other"
+
+
+def _normalize_customer_source_to_zoho_dropdown(source: str) -> str:
+    text = str(source or "").strip().upper().replace("-", "_").replace(" ", "_")
+    if "EBAY" in text:
+        return "Ebay"
+    if "WALMART" in text:
+        return "Walmart"
+    if "ECWID" in text:
+        return "Ecwid"
+    if "AMAZON" in text:
+        return "Amazon"
+    if "SHIPSTATION" in text:
+        return "ShipStation"
+    return "Other"
+
+
+def _resolve_customer_source_to_zoho_dropdown(source: str) -> str:
+    normalized = str(source or "").strip().upper()
+    mapped = EXACT_ZOHO_CONTACT_SOURCE_MAP.get(normalized)
+    if mapped:
+        return mapped
+
+    fallback = _normalize_customer_source_to_zoho_dropdown(source)
+    if fallback in VALID_ZOHO_CONTACT_SOURCE_VALUES:
+        return fallback
+    return "Other"
+
+
+def _extract_contact_source_custom_field(data: dict[str, Any]) -> Optional[str]:
+    custom_fields = data.get("custom_fields") or []
+    if not isinstance(custom_fields, list):
+        return None
+
+    target_api_name = str(settings.zoho_contact_cf_source_api_name or "cf_source").strip().lower()
+    for field in custom_fields:
+        if not isinstance(field, dict):
+            continue
+        api_name = str(field.get("api_name") or "").strip().lower()
+        label = str(field.get("label") or "").strip().lower()
+        if api_name == target_api_name or label in {"source", "customer source", "channel"}:
+            value = field.get("value")
+            if value is None:
+                continue
+            text_value = str(value).strip()
+            return text_value or None
+
+    return None
 
 
 def purchase_order_to_zoho_payload(
@@ -1102,6 +1184,9 @@ def zoho_contact_to_customer_fields(data: dict) -> dict[str, Any]:
         fields["postal_code"] = addr["zip"]
     if addr.get("country"):
         fields["country"] = addr["country"]
+    source_value = _extract_contact_source_custom_field(data)
+    if source_value:
+        fields["source"] = source_value
     return fields
 
 

--- a/Backend/app/models/entities.py
+++ b/Backend/app/models/entities.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -723,11 +724,11 @@ class PlatformListing(Base, TimestampMixin):
         primary_key=True,
         autoincrement=True,
     )
-    variant_id: Mapped[int] = mapped_column(
+    variant_id: Mapped[Optional[int]] = mapped_column(
         BigInteger,
         ForeignKey("product_variant.id", ondelete="CASCADE"),
-        nullable=False,
-        comment="The specific item being sold.",
+        nullable=True,
+        comment="Matched internal SKU variant; NULL means unresolved listing.",
     )
     platform: Mapped[Platform] = mapped_column(
         Enum(Platform, name="platform_enum"),
@@ -737,7 +738,12 @@ class PlatformListing(Base, TimestampMixin):
     external_ref_id: Mapped[Optional[str]] = mapped_column(
         String(100),
         nullable=True,
-        comment="The ID on the remote platform (Zoho Item ID, ASIN).",
+        comment="Canonical platform listing ID (not merchant SKU).",
+    )
+    merchant_sku: Mapped[Optional[str]] = mapped_column(
+        String(100),
+        nullable=True,
+        comment="Marketplace merchant SKU for fallback lookup only.",
     )
     listed_name: Mapped[Optional[str]] = mapped_column(
         String(500),
@@ -777,21 +783,23 @@ class PlatformListing(Base, TimestampMixin):
     )
     
     # Relationships
-    variant: Mapped["ProductVariant"] = relationship(
+    variant: Mapped[Optional["ProductVariant"]] = relationship(
         "ProductVariant",
         back_populates="listings",
     )
     
     __table_args__ = (
-        # One listing per variant per platform
-        UniqueConstraint(
-            "variant_id", "platform",
-            name="uq_listing_variant_platform",
-        ),
         Index("ix_listing_variant_id", "variant_id"),
         Index("ix_listing_platform", "platform"),
         Index("ix_listing_sync_status", "sync_status"),
-        Index("ix_listing_external_ref", "platform", "external_ref_id"),
+        Index(
+            "ix_listing_external_ref",
+            "platform",
+            "external_ref_id",
+            unique=True,
+            postgresql_where=text("external_ref_id IS NOT NULL"),
+        ),
+        Index("ix_listing_platform_merchant_sku", "platform", "merchant_sku"),
     )
     
     def __repr__(self) -> str:
@@ -919,6 +927,11 @@ class Customer(Base, ZohoSyncMixin, TimestampMixin):
         nullable=True,
         comment="Company / organisation name.",
     )
+    source: Mapped[Optional[str]] = mapped_column(
+        String(50),
+        nullable=True,
+        comment="Latest known customer acquisition source (ECWID_API, WALMART_API, SHIPSTATION_CSV, etc.).",
+    )
 
     # ---- Address ----
     address_line1: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
@@ -947,6 +960,7 @@ class Customer(Base, ZohoSyncMixin, TimestampMixin):
     __table_args__ = (
         Index("ix_customer_email", "email"),
         Index("ix_customer_name", "name"),
+        Index("ix_customer_source", "source"),
         Index("ix_customer_zoho_id", "zoho_id"),
     )
 

--- a/Backend/app/modules/orders/models.py
+++ b/Backend/app/modules/orders/models.py
@@ -36,7 +36,7 @@ from app.models.entities import TimestampMixin, ZohoSyncMixin, ZohoSyncStatus
 
 if TYPE_CHECKING:
     from typing import List
-    from app.models.entities import ProductVariant, InventoryItem, Customer
+    from app.models.entities import ProductVariant, InventoryItem, Customer, PlatformListing
 
 
 # ============================================================================
@@ -366,11 +366,17 @@ class OrderItem(Base, TimestampMixin):
     )
 
     # ---- Internal Matching ----
+    platform_listing_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger,
+        ForeignKey("platform_listing.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="Resolved platform listing for this order line.",
+    )
     variant_id: Mapped[Optional[int]] = mapped_column(
         BigInteger,
         ForeignKey("product_variant.id", ondelete="SET NULL"),
         nullable=True,
-        comment="Matched internal product variant.",
+        comment="Denormalized matched variant for query speed.",
     )
     allocated_inventory_id: Mapped[Optional[int]] = mapped_column(
         BigInteger,
@@ -418,6 +424,10 @@ class OrderItem(Base, TimestampMixin):
         "Order",
         back_populates="items",
     )
+    platform_listing: Mapped[Optional["PlatformListing"]] = relationship(
+        "PlatformListing",
+        lazy="selectin",
+    )
     variant: Mapped[Optional["ProductVariant"]] = relationship(
         "ProductVariant",
         lazy="selectin",
@@ -431,6 +441,7 @@ class OrderItem(Base, TimestampMixin):
         CheckConstraint("quantity > 0", name="ck_order_item_positive_quantity"),
         CheckConstraint("unit_price >= 0", name="ck_order_item_non_negative_price"),
         Index("ix_order_item_order_id", "order_id"),
+        Index("ix_order_item_platform_listing_id", "platform_listing_id"),
         Index("ix_order_item_variant_id", "variant_id"),
         Index("ix_order_item_status", "status"),
         Index("ix_order_item_external_sku", "external_sku"),

--- a/Backend/app/modules/orders/routes.py
+++ b/Backend/app/modules/orders/routes.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -63,6 +64,7 @@ from app.modules.orders.schemas.sync import (
     SyncResponse,
     SyncStatusResponse,
 )
+from app.models.entities import Customer
 from app.modules.orders.service import OrderSyncService
 from app.repositories.orders.order_repository import OrderItemRepository, OrderRepository
 from app.repositories.orders.sync_repository import SyncRepository
@@ -272,6 +274,86 @@ def _parse_order_csv(file_text: str) -> tuple[list[dict], int, int]:
     return list(grouped.values()), seen, skipped
 
 
+def _coalesce(value: Optional[str]) -> Optional[str]:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _pick_first_nonempty(row: dict[str, str], keys: list[str]) -> Optional[str]:
+    for key in keys:
+        value = _coalesce(row.get(key))
+        if value:
+            return value
+    return None
+
+
+def _parse_shipstation_customer_csv(file_text: str) -> tuple[list[dict], int, int]:
+    reader = csv.DictReader(io.StringIO(file_text))
+    seen = 0
+    skipped = 0
+    deduped: dict[str, dict] = {}
+
+    for row in reader:
+        seen += 1
+        email = _pick_first_nonempty(row, ["Customer Email", "Buyer Email"])
+        name = _pick_first_nonempty(row, ["Bill To Name", "Ship To Name", "Customer Name"])
+        phone = _pick_first_nonempty(row, ["Bill To Phone", "Ship To Phone", "Customer Phone"])
+        company = _pick_first_nonempty(row, ["Bill To Company", "Ship To Company", "Company"])
+
+        address_line1 = _pick_first_nonempty(row, ["Bill To Address 1", "Ship To Address 1"])
+        address_line2 = _pick_first_nonempty(row, ["Bill To Address 2", "Ship To Address 2"])
+        city = _pick_first_nonempty(row, ["Bill To City", "Ship To City"])
+        state = _pick_first_nonempty(row, ["Bill To State", "Ship To State"])
+        postal_code = _pick_first_nonempty(row, ["Bill To Postal", "Ship To Postal", "Bill To Zip", "Ship To Zip"])
+        country = _pick_first_nonempty(row, ["Bill To Country", "Ship To Country", "Ship To Country Code"]) or "US"
+
+        source = (
+            _pick_first_nonempty(row, ["Advanced Options Source", "Order Source", "Source"])
+            or "SHIPSTATION_CSV"
+        )
+
+        if not (email or name or phone):
+            skipped += 1
+            continue
+
+        dedupe_key = (email or "").lower() or f"{(name or '').lower()}|{(postal_code or '').lower()}"
+        existing = deduped.get(dedupe_key)
+        if not existing:
+            deduped[dedupe_key] = {
+                "name": name,
+                "email": email,
+                "phone": phone,
+                "company_name": company,
+                "address_line1": address_line1,
+                "address_line2": address_line2,
+                "city": city,
+                "state": state,
+                "postal_code": postal_code,
+                "country": country,
+                "source": source,
+            }
+            continue
+
+        # Keep the richest row when the same customer appears in multiple orders.
+        for key, value in {
+            "name": name,
+            "email": email,
+            "phone": phone,
+            "company_name": company,
+            "address_line1": address_line1,
+            "address_line2": address_line2,
+            "city": city,
+            "state": state,
+            "postal_code": postal_code,
+            "country": country,
+            "source": source,
+        }.items():
+            if value and not _coalesce(existing.get(key)):
+                existing[key] = value
+
+    return list(deduped.values()), seen, skipped
+
+
 # ============================================================================
 # SYNC ENDPOINTS
 # ============================================================================
@@ -445,8 +527,9 @@ async def import_orders_from_file(
     source: Annotated[SalesImportFileSource, Query()],
     file: UploadFile = File(...),
     service: OrderSyncService = Depends(get_order_sync_service),
+    db: AsyncSession = Depends(get_db),
 ):
-    if source != SalesImportFileSource.CSV_GENERIC:
+    if source not in {SalesImportFileSource.CSV_GENERIC, SalesImportFileSource.SHIPSTATION_CUSTOMER_CSV}:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Unsupported import source",
@@ -466,6 +549,109 @@ async def import_orders_from_file(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="CSV must be UTF-8 encoded.",
         ) from exc
+
+    if source == SalesImportFileSource.SHIPSTATION_CUSTOMER_CSV:
+        customers, rows_seen, rows_skipped = _parse_shipstation_customer_csv(text)
+        created = 0
+        updated = 0
+
+        for payload in customers:
+            email = _coalesce(payload.get("email"))
+            name = _coalesce(payload.get("name"))
+            postal_code = _coalesce(payload.get("postal_code"))
+            phone = _coalesce(payload.get("phone"))
+            source_value = _coalesce(payload.get("source")) or "SHIPSTATION_CSV"
+
+            customer: Optional[Customer] = None
+
+            if email:
+                existing = await db.execute(select(Customer).where(Customer.email == email))
+                customer = existing.scalar_one_or_none()
+
+            if customer is None and name:
+                query = select(Customer).where(Customer.name == name)
+                if postal_code:
+                    query = query.where(Customer.postal_code == postal_code)
+                existing = await db.execute(query)
+                customer = existing.scalar_one_or_none()
+
+            if customer is None and phone:
+                existing = await db.execute(select(Customer).where(Customer.phone == phone))
+                customer = existing.scalar_one_or_none()
+
+            if customer is None:
+                customer = Customer(
+                    name=name or "Unknown",
+                    email=email,
+                    phone=phone,
+                    company_name=_coalesce(payload.get("company_name")),
+                    address_line1=_coalesce(payload.get("address_line1")),
+                    address_line2=_coalesce(payload.get("address_line2")),
+                    city=_coalesce(payload.get("city")),
+                    state=_coalesce(payload.get("state")),
+                    postal_code=postal_code,
+                    country=_coalesce(payload.get("country")) or "US",
+                    source=source_value,
+                    is_active=True,
+                )
+                db.add(customer)
+                created += 1
+                continue
+
+            changed = False
+            if name and (not _coalesce(customer.name) or customer.name == "Unknown"):
+                customer.name = name
+                changed = True
+            if email and not _coalesce(customer.email):
+                customer.email = email
+                changed = True
+            if phone and not _coalesce(customer.phone):
+                customer.phone = phone
+                changed = True
+            if _coalesce(payload.get("company_name")) and not _coalesce(customer.company_name):
+                customer.company_name = _coalesce(payload.get("company_name"))
+                changed = True
+            if _coalesce(payload.get("address_line1")) and not _coalesce(customer.address_line1):
+                customer.address_line1 = _coalesce(payload.get("address_line1"))
+                changed = True
+            if _coalesce(payload.get("address_line2")) and not _coalesce(customer.address_line2):
+                customer.address_line2 = _coalesce(payload.get("address_line2"))
+                changed = True
+            if _coalesce(payload.get("city")) and not _coalesce(customer.city):
+                customer.city = _coalesce(payload.get("city"))
+                changed = True
+            if _coalesce(payload.get("state")) and not _coalesce(customer.state):
+                customer.state = _coalesce(payload.get("state"))
+                changed = True
+            if postal_code and not _coalesce(customer.postal_code):
+                customer.postal_code = postal_code
+                changed = True
+            if _coalesce(payload.get("country")) and not _coalesce(customer.country):
+                customer.country = _coalesce(payload.get("country"))
+                changed = True
+            if source_value != customer.source:
+                customer.source = source_value
+                changed = True
+
+            if changed:
+                db.add(customer)
+                updated += 1
+
+        await db.commit()
+
+        return SalesImportFileResponse(
+            source=source,
+            source_rows_seen=rows_seen,
+            source_rows_skipped=rows_skipped,
+            customers_created=created,
+            customers_updated=updated,
+            new_orders=0,
+            new_items=0,
+            auto_matched=0,
+            skipped_duplicates=0,
+            success=True,
+            errors=[],
+        )
 
     rows, rows_seen, rows_skipped = _parse_order_csv(text)
     external_orders: list[ExternalOrder] = []

--- a/Backend/app/modules/orders/routes.py
+++ b/Backend/app/modules/orders/routes.py
@@ -204,54 +204,91 @@ def _parse_order_csv(file_text: str) -> tuple[list[dict], int, int]:
     seen = 0
     skipped = 0
 
+    def _pick(*keys: str) -> str:
+        for key in keys:
+            value = (row.get(key) or "").strip()
+            if value:
+                return value
+        return ""
+
+    def _as_float(*keys: str, default: float = 0.0) -> float:
+        value = _pick(*keys)
+        if not value:
+            return default
+        try:
+            return float(value)
+        except ValueError:
+            return default
+
+    def _as_int(*keys: str, default: int = 1) -> int:
+        value = _pick(*keys)
+        if not value:
+            return default
+        try:
+            parsed = int(value)
+            return parsed if parsed > 0 else default
+        except ValueError:
+            return default
+
     for row in reader:
         seen += 1
-        ext_order_id = (row.get("external_order_id") or row.get("order_id") or "").strip()
-        item_name = (row.get("item_name") or row.get("title") or "").strip()
-        if not ext_order_id or not item_name:
+        ext_order_id = _pick("external_order_id", "order_id", "Order - CustomerID", "Order - Number")
+        item_name = _pick("item_name", "title", "Item Name", "Product Name")
+
+        # ShipStation order export rows usually don't include per-item columns.
+        # Keep those rows importable by creating a synthetic line item.
+        quantity = _as_int("quantity", "Count - Number of Items", default=1)
+        subtotal_amount = _as_float("subtotal_amount", "subtotal", "Amount - Order Subtotal", default=0.0)
+        total_amount = _as_float("total_amount", "total", "Amount - Order Total", default=0.0)
+        item_total = subtotal_amount if subtotal_amount > 0 else total_amount
+        if not item_name:
+            item_name = "Imported order line"
+
+        if not ext_order_id:
             skipped += 1
             continue
 
-        external_item_id = (row.get("external_item_id") or "").strip() or None
-        external_sku = (row.get("external_sku") or row.get("sku") or "").strip() or None
-        quantity_text = (row.get("quantity") or "1").strip()
-        unit_price_text = (row.get("unit_price") or "0").strip()
-        total_price_text = (row.get("total_price") or "").strip()
+        external_item_id = _pick("external_item_id", "Order - Number") or None
+        external_sku = _pick("external_sku", "sku", "SKU") or None
+        unit_price_text = _pick("unit_price")
+        total_price_text = _pick("total_price")
 
         try:
-            quantity = int(quantity_text)
-            unit_price = float(unit_price_text)
-            total_price = float(total_price_text) if total_price_text else unit_price * quantity
+            unit_price = float(unit_price_text) if unit_price_text else (item_total / quantity if quantity > 0 else 0.0)
+            total_price = float(total_price_text) if total_price_text else item_total
         except ValueError:
             skipped += 1
             continue
 
         ordered_at = None
-        ordered_at_raw = (row.get("ordered_at") or "").strip()
+        ordered_at_raw = _pick("ordered_at", "Date - Order Date")
         if ordered_at_raw:
             try:
                 ordered_at = datetime.fromisoformat(ordered_at_raw.replace("Z", "+00:00"))
             except ValueError:
-                ordered_at = None
+                try:
+                    ordered_at = datetime.strptime(ordered_at_raw, "%m/%d/%Y %I:%M:%S %p")
+                except ValueError:
+                    ordered_at = None
 
         order_entry = grouped.setdefault(
             ext_order_id,
             {
                 "platform_order_id": ext_order_id,
-                "platform_order_number": (row.get("external_order_number") or row.get("order_number") or "").strip() or None,
-                "customer_name": (row.get("customer_name") or "").strip() or None,
-                "customer_email": (row.get("customer_email") or "").strip() or None,
-                "ship_address_line1": (row.get("shipping_address_line1") or "").strip() or None,
-                "ship_address_line2": (row.get("shipping_address_line2") or "").strip() or None,
-                "ship_city": (row.get("shipping_city") or "").strip() or None,
-                "ship_state": (row.get("shipping_state") or "").strip() or None,
-                "ship_postal_code": (row.get("shipping_postal_code") or "").strip() or None,
-                "ship_country": (row.get("shipping_country") or "").strip() or "US",
-                "subtotal": float((row.get("subtotal_amount") or row.get("subtotal") or "0").strip() or "0"),
-                "tax": float((row.get("tax_amount") or row.get("tax") or "0").strip() or "0"),
-                "shipping": float((row.get("shipping_amount") or row.get("shipping") or "0").strip() or "0"),
-                "total": float((row.get("total_amount") or row.get("total") or "0").strip() or "0"),
-                "currency": (row.get("currency") or "USD").strip() or "USD",
+                "platform_order_number": _pick("external_order_number", "order_number", "Order - Number") or None,
+                "customer_name": _pick("customer_name", "Bill To - Name", "Ship To - Name") or None,
+                "customer_email": _pick("customer_email", "Customer Email") or None,
+                "ship_address_line1": _pick("shipping_address_line1", "Ship To - Address 1") or None,
+                "ship_address_line2": _pick("shipping_address_line2", "Ship To - Address 2") or None,
+                "ship_city": _pick("shipping_city", "Ship To - City") or None,
+                "ship_state": _pick("shipping_state", "Ship To - State") or None,
+                "ship_postal_code": _pick("shipping_postal_code", "Ship To - Postal Code") or None,
+                "ship_country": _pick("shipping_country", "Ship To - Country") or "US",
+                "subtotal": subtotal_amount,
+                "tax": _as_float("tax_amount", "tax", "Amount - Order Tax", default=0.0),
+                "shipping": _as_float("shipping_amount", "shipping", "Amount - Order Shipping", default=0.0),
+                "total": total_amount,
+                "currency": _pick("currency") or "USD",
                 "ordered_at": ordered_at,
                 "items": [],
                 "raw_data": {"import_source": "CSV_GENERIC"},

--- a/Backend/app/modules/orders/schemas/sync.py
+++ b/Backend/app/modules/orders/schemas/sync.py
@@ -85,6 +85,7 @@ class SalesImportApiSource(str, Enum):
 
 class SalesImportFileSource(str, Enum):
     CSV_GENERIC = "CSV_GENERIC"
+    SHIPSTATION_CUSTOMER_CSV = "SHIPSTATION_CUSTOMER_CSV"
 
 
 class SalesImportApiRequest(BaseModel):
@@ -97,6 +98,8 @@ class SalesImportFileResponse(BaseModel):
     source: SalesImportFileSource
     source_rows_seen: int = 0
     source_rows_skipped: int = 0
+    customers_created: int = 0
+    customers_updated: int = 0
     new_orders: int = 0
     new_items: int = 0
     auto_matched: int = 0

--- a/Backend/app/modules/orders/service.py
+++ b/Backend/app/modules/orders/service.py
@@ -343,7 +343,7 @@ class OrderSyncService:
             return False
 
         # Upsert/lookup Customer (if any data is available)
-        customer_id = await self._get_or_create_customer(ext)
+        customer_id = await self._get_or_create_customer(ext, source=source)
 
         # Build the Order header
         order_data = {
@@ -389,9 +389,62 @@ class OrderSyncService:
     def _platform_source(platform_name: str) -> str:
         return f"{platform_name.upper()}_API"
 
-    async def _get_or_create_customer(self, ext: ExternalOrder) -> Optional[int]:
+    @staticmethod
+    def _coalesce(value: Optional[str]) -> Optional[str]:
+        text = str(value or "").strip()
+        return text or None
+
+    def _merge_customer_fields(self, customer: Customer, ext: ExternalOrder, source: Optional[str]) -> bool:
+        changed = False
+
+        incoming_name = self._coalesce(ext.customer_name)
+        incoming_email = self._coalesce(ext.customer_email)
+        incoming_phone = self._coalesce(ext.customer_phone)
+        incoming_company = self._coalesce(ext.customer_company)
+        incoming_source = self._coalesce(ext.customer_source) or self._coalesce(source)
+
+        if incoming_name and (not self._coalesce(customer.name) or customer.name == "Unknown"):
+            customer.name = incoming_name
+            changed = True
+        if incoming_email and not self._coalesce(customer.email):
+            customer.email = incoming_email
+            changed = True
+        if incoming_phone and not self._coalesce(customer.phone):
+            customer.phone = incoming_phone
+            changed = True
+        if incoming_company and not self._coalesce(customer.company_name):
+            customer.company_name = incoming_company
+            changed = True
+
+        if ext.ship_address_line1 and not self._coalesce(customer.address_line1):
+            customer.address_line1 = ext.ship_address_line1
+            changed = True
+        if ext.ship_address_line2 and not self._coalesce(customer.address_line2):
+            customer.address_line2 = ext.ship_address_line2
+            changed = True
+        if ext.ship_city and not self._coalesce(customer.city):
+            customer.city = ext.ship_city
+            changed = True
+        if ext.ship_state and not self._coalesce(customer.state):
+            customer.state = ext.ship_state
+            changed = True
+        if ext.ship_postal_code and not self._coalesce(customer.postal_code):
+            customer.postal_code = ext.ship_postal_code
+            changed = True
+        if ext.ship_country and not self._coalesce(customer.country):
+            customer.country = ext.ship_country
+            changed = True
+
+        # Keep latest known source; this is intentionally overwrite-oriented.
+        if incoming_source and incoming_source != customer.source:
+            customer.source = incoming_source
+            changed = True
+
+        return changed
+
+    async def _get_or_create_customer(self, ext: ExternalOrder, *, source: Optional[str]) -> Optional[int]:
         """Find or create a Customer from external order details."""
-        if not (ext.customer_name or ext.customer_email):
+        if not (ext.customer_name or ext.customer_email or ext.customer_phone):
             return None
 
         # Prefer email for deterministic matching
@@ -401,6 +454,8 @@ class OrderSyncService:
             )
             customer = existing.scalar_one_or_none()
             if customer:
+                if self._merge_customer_fields(customer, ext, source):
+                    self.session.add(customer)
                 return customer.id
 
         # Fallback: match by name + postal code if available
@@ -411,20 +466,23 @@ class OrderSyncService:
             existing = await self.session.execute(query)
             customer = existing.scalar_one_or_none()
             if customer:
+                if self._merge_customer_fields(customer, ext, source):
+                    self.session.add(customer)
                 return customer.id
 
         # Create new customer
         customer = Customer(
             name=ext.customer_name or "Unknown",
             email=ext.customer_email,
-            phone=None,
-            company_name=None,
+            phone=ext.customer_phone,
+            company_name=ext.customer_company,
             address_line1=ext.ship_address_line1,
             address_line2=ext.ship_address_line2,
             city=ext.ship_city,
             state=ext.ship_state,
             postal_code=ext.ship_postal_code,
             country=ext.ship_country or "US",
+            source=self._coalesce(ext.customer_source) or self._coalesce(source),
             is_active=True,
         )
         self.session.add(customer)

--- a/Backend/app/modules/orders/service.py
+++ b/Backend/app/modules/orders/service.py
@@ -36,6 +36,11 @@ from app.repositories.orders.sync_repository import SyncRepository
 
 logger = logging.getLogger(__name__)
 
+_NON_BLOCKING_AUTH_ERROR_MARKERS = (
+    "unable to obtain access token",
+    "credentials not configured",
+)
+
 # Mapping from IntegrationState platform_name → OrderPlatform enum
 _PLATFORM_MAP: dict[str, OrderPlatform] = {
     "AMAZON": OrderPlatform.AMAZON,
@@ -111,6 +116,21 @@ class OrderSyncService:
         logger.debug(f"[DEBUG.INTERNAL_API] {platform_name}: Attempting to acquire sync lock")
         locked = await self.sync_repo.acquire_sync_lock(platform_name)
         logger.debug(f"[DEBUG.INTERNAL_API] {platform_name}: Lock acquired={locked}")
+        if not locked:
+            state = await self.sync_repo.get_by_platform(platform_name)
+            state_error = (state.last_error_message or "").lower() if state else ""
+            if state and state.current_status == IntegrationSyncStatus.ERROR and any(
+                marker in state_error for marker in _NON_BLOCKING_AUTH_ERROR_MARKERS
+            ):
+                logger.info(
+                    "%s: Auto-resetting prior auth/config error state to retry sync.",
+                    platform_name,
+                )
+                await self.sync_repo.reset_to_idle(platform_name)
+                await self.session.flush()
+                locked = await self.sync_repo.acquire_sync_lock(platform_name)
+                logger.debug(f"[DEBUG.INTERNAL_API] {platform_name}: Lock acquired after auto-reset={locked}")
+
         if not locked:
             response.success = False
             error_msg = f"Platform '{platform_name}' is currently syncing or in error. Reset the state before retrying."

--- a/Backend/migrations/versions/20260416_000000_0024_add_customer_source.py
+++ b/Backend/migrations/versions/20260416_000000_0024_add_customer_source.py
@@ -1,0 +1,27 @@
+"""Add customer source column.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-04-16 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0024"
+down_revision: Union[str, None] = "0023"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("customer", sa.Column("source", sa.String(length=50), nullable=True))
+    op.create_index("ix_customer_source", "customer", ["source"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_customer_source", table_name="customer")
+    op.drop_column("customer", "source")

--- a/Backend/migrations/versions/20260427_000000_0025_platform_listing_centric_matching_foundation.py
+++ b/Backend/migrations/versions/20260427_000000_0025_platform_listing_centric_matching_foundation.py
@@ -1,0 +1,124 @@
+"""Platform listing-centric matching foundation.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-04-27 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "0025"
+down_revision: Union[str, None] = "0024"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1) platform_listing: variant nullable + merchant_sku
+    op.add_column(
+        "platform_listing",
+        sa.Column("merchant_sku", sa.String(length=100), nullable=True),
+    )
+    op.alter_column(
+        "platform_listing",
+        "variant_id",
+        existing_type=sa.BigInteger(),
+        nullable=True,
+    )
+
+    # 2) order_item: add platform_listing_id
+    op.add_column(
+        "order_item",
+        sa.Column("platform_listing_id", sa.BigInteger(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_order_item_platform_listing_id_platform_listing",
+        "order_item",
+        "platform_listing",
+        ["platform_listing_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_order_item_platform_listing_id",
+        "order_item",
+        ["platform_listing_id"],
+        unique=False,
+    )
+
+    # 3) replace listing constraints/indexes
+    op.drop_constraint("uq_listing_variant_platform", "platform_listing", type_="unique")
+    op.drop_index("ix_listing_external_ref", table_name="platform_listing")
+
+    op.create_index(
+        "ix_listing_external_ref",
+        "platform_listing",
+        ["platform", "external_ref_id"],
+        unique=True,
+        postgresql_where=sa.text("external_ref_id IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_listing_platform_merchant_sku",
+        "platform_listing",
+        ["platform", "merchant_sku"],
+        unique=False,
+    )
+
+    # 4) data backfill:
+    # backfill order_item.platform_listing_id from existing variant_id + order.platform
+    # using enum text compare because order/platform enums are different SQL enum types.
+    op.execute(
+        """
+        UPDATE order_item AS oi
+        SET platform_listing_id = pl.id
+        FROM orders AS o, platform_listing AS pl
+        WHERE oi.order_id = o.id
+          AND oi.variant_id IS NOT NULL
+          AND oi.platform_listing_id IS NULL
+          AND pl.variant_id = oi.variant_id
+          AND pl.platform::text = o.platform::text
+        """
+    )
+
+
+def downgrade() -> None:
+    # Drop new indexes first
+    op.drop_index("ix_listing_platform_merchant_sku", table_name="platform_listing")
+    op.drop_index("ix_listing_external_ref", table_name="platform_listing")
+
+    # Restore pre-existing non-unique external ref index
+    op.create_index(
+        "ix_listing_external_ref",
+        "platform_listing",
+        ["platform", "external_ref_id"],
+        unique=False,
+    )
+
+    # Restore unique constraint (best effort)
+    op.create_unique_constraint(
+        "uq_listing_variant_platform",
+        "platform_listing",
+        ["variant_id", "platform"],
+    )
+
+    # Remove order_item.platform_listing_id
+    op.drop_index("ix_order_item_platform_listing_id", table_name="order_item")
+    op.drop_constraint(
+        "fk_order_item_platform_listing_id_platform_listing",
+        "order_item",
+        type_="foreignkey",
+    )
+    op.drop_column("order_item", "platform_listing_id")
+
+    # Remove merchant_sku and enforce legacy NOT NULL on variant_id
+    op.drop_column("platform_listing", "merchant_sku")
+    op.alter_column(
+        "platform_listing",
+        "variant_id",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+    )

--- a/Docs/Docker_Documentation.md
+++ b/Docs/Docker_Documentation.md
@@ -70,6 +70,8 @@ This will:
 - Start database, database backups normally
 - Run backend with code reloading
 - Run frontend with Vite hot reload
+- Skip host `/mnt/product_images` mounts (not required in local dev)
+- Run Zoho sync actions without image upload in dev UI by default
 - Changes to code are reflected immediately without rebuilding
 
 **Access:**
@@ -197,6 +199,11 @@ docker-compose restart backend
 ### Hot reload not working in dev mode:
 - Ensure volumes are correctly mounted
 - Restart the container: `docker-compose --profile dev restart frontend-dev`
+
+### `/mnt/product_images` missing on local machine:
+- Dev profile no longer requires `/mnt/product_images`.
+- `backend-dev` uses container-local `PRODUCT_IMAGES_PATH=/tmp/usav_product_images`.
+- Product thumbnails/uploads are intentionally disabled in dev UI (`VITE_DISABLE_PRODUCT_IMAGES=true`).
 
 ### Out of disk space:
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
       - EBAY_REFRESH_TOKEN_PURCHASING=${EBAY_REFRESH_TOKEN_PURCHASING:-}
       - EBAY_REFRESH_TOKEN_USAV=${EBAY_REFRESH_TOKEN_USAV:-}
       - EBAY_REFRESH_TOKEN_DRAGON=${EBAY_REFRESH_TOKEN_DRAGON:-}
+      - WALMART_CLIENT_ID=${WALMART_CLIENT_ID:-}
+      - WALMART_CLIENT_SECRET=${WALMART_CLIENT_SECRET:-}
     ports:
       - "8080:8080"
     depends_on:
@@ -87,10 +89,10 @@ services:
     command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
     volumes:
       - ./Backend:/app
-      - /mnt/product_images:/mnt/product_images
     environment:
       - DEBUG=true
       - ENVIRONMENT=development
+      - SEATALK_REDIRECT_URI=${SEATALK_REDIRECT_URI_DEVELOPMENT:-`}
       - DB_HOST=db
       - DB_PORT=5432
       - DB_USER=${DB_USER:-postgres}
@@ -110,8 +112,11 @@ services:
       - ZOHO_CLIENT_SECRET=${ZOHO_CLIENT_SECRET:-}
       - ZOHO_REFRESH_TOKEN=${ZOHO_REFRESH_TOKEN:-}
       - ZOHO_ORGANIZATION_ID=${ZOHO_ORGANIZATION_ID:-}
+      - WALMART_CLIENT_ID=${WALMART_CLIENT_ID:-}
+      - WALMART_CLIENT_SECRET=${WALMART_CLIENT_SECRET:-}
       - ZOHO_AUTO_OUTBOUND_SYNC_ENABLED=false
       - ZOHO_AUTO_INBOUND_SYNC_ENABLED=false
+      - PRODUCT_IMAGES_PATH=/tmp/usav_product_images
     ports:
       - "8080:8080"
     depends_on:
@@ -221,10 +226,10 @@ services:
       - ./frontend/vite.config.ts:/app/vite.config.ts
       - ./frontend/tsconfig.json:/app/tsconfig.json
       - ./frontend/tsconfig.node.json:/app/tsconfig.node.json
-      - /mnt/product_images:/app/public/product-images:ro
     environment:
       - VITE_SEATALK_APP_ID=${SEATALK_APP_ID:-}
-      - VITE_SEATALK_REDIRECT_URI=${SEATALK_REDIRECT_URI:-}
+      - VITE_SEATALK_REDIRECT_URI=http://localhost:3636/auth/seatalk/callback
+      - VITE_DISABLE_PRODUCT_IMAGES=true
     ports:
       - "3636:3636"
     depends_on:

--- a/frontend/src/components/common/OrderSummaryCards.tsx
+++ b/frontend/src/components/common/OrderSummaryCards.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, Grid, Typography } from '@mui/material'
+
+interface OrderSummaryCardsProps {
+  totalOrders: number
+  unmatchedOrders: number
+  unmatchedItems: number
+}
+
+export default function OrderSummaryCards({
+  totalOrders,
+  unmatchedOrders,
+  unmatchedItems,
+}: OrderSummaryCardsProps) {
+  return (
+    <Grid container spacing={2} sx={{ mb: 3 }}>
+      <Grid item xs={12} sm={4}>
+        <Card>
+          <CardContent sx={{ py: 1.5 }}>
+            <Typography color="text.secondary" variant="body2">
+              Total Orders
+            </Typography>
+            <Typography variant="h5">{totalOrders}</Typography>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <Card>
+          <CardContent sx={{ py: 1.5 }}>
+            <Typography color="text.secondary" variant="body2">
+              Unmatched Orders
+            </Typography>
+            <Typography variant="h5" color="warning.main">
+              {unmatchedOrders}
+            </Typography>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} sm={4}>
+        <Card>
+          <CardContent sx={{ py: 1.5 }}>
+            <Typography color="text.secondary" variant="body2">
+              Unmatched Items
+            </Typography>
+            <Typography variant="h5" color="error.main">
+              {unmatchedItems}
+            </Typography>
+          </CardContent>
+        </Card>
+      </Grid>
+    </Grid>
+  )
+}

--- a/frontend/src/components/inventory/ProductThumbnail.tsx
+++ b/frontend/src/components/inventory/ProductThumbnail.tsx
@@ -10,6 +10,7 @@ interface ProductThumbnailProps {
 }
 
 export default function ProductThumbnail({ sku, thumbnailUrl, size = 40, onClick }: ProductThumbnailProps) {
+  const disableProductImages = import.meta.env.VITE_DISABLE_PRODUCT_IMAGES === 'true'
   const [hasError, setHasError] = useState(false)
   const [isLoaded, setIsLoaded] = useState(false)
   const [fallbackMode, setFallbackMode] = useState(false)
@@ -31,6 +32,9 @@ export default function ProductThumbnail({ sku, thumbnailUrl, size = 40, onClick
   }, [sku, thumbnailUrl])
 
   useEffect(() => {
+    if (disableProductImages) {
+      return
+    }
     const imageEl = imgRef.current
     if (!imageEl) return
 
@@ -42,7 +46,27 @@ export default function ProductThumbnail({ sku, thumbnailUrl, size = 40, onClick
         setHasError(true)
       }
     }
-  }, [resolvedThumbnailUrl])
+  }, [disableProductImages, resolvedThumbnailUrl])
+
+  if (disableProductImages) {
+    return (
+      <Box
+        sx={{
+          width: size,
+          height: size,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          bgcolor: 'grey.100',
+          borderRadius: 0.5,
+          color: 'grey.400',
+          cursor: 'default',
+        }}
+      >
+        <ImageNotSupported sx={{ fontSize: size * 0.5 }} />
+      </Box>
+    )
+  }
 
   if (hasError) {
     return (

--- a/frontend/src/components/orders/OrderImportButton.tsx
+++ b/frontend/src/components/orders/OrderImportButton.tsx
@@ -45,8 +45,8 @@ export default function OrderImportButton() {
     mutationFn: () =>
       importOrdersFromApi({
         source: apiSource,
-        since: new Date(since).toISOString(),
-        until: new Date(until).toISOString(),
+        since: new Date(`${since}T00:00:00`).toISOString(),
+        until: new Date(`${until}T23:59:59.999`).toISOString(),
       }),
     onSuccess: (data) => {
       setMessage(`Imported ${data.new_orders} orders (${data.new_items} items).`)
@@ -99,7 +99,7 @@ export default function OrderImportButton() {
     csvMutation.mutate()
   }
 
-  const canRunApi = Boolean(since && until && new Date(since) < new Date(until))
+  const canRunApi = Boolean(since && until && new Date(since) <= new Date(until))
   const canRun = mode === 'api' ? canRunApi : Boolean(csvFile)
 
   return (
@@ -136,7 +136,7 @@ export default function OrderImportButton() {
                   </Select>
                 </FormControl>
                 <TextField
-                  type="datetime-local"
+                  type="date"
                   label="Since"
                   value={since}
                   onChange={(e) => setSince(e.target.value)}
@@ -144,7 +144,7 @@ export default function OrderImportButton() {
                   fullWidth
                 />
                 <TextField
-                  type="datetime-local"
+                  type="date"
                   label="Until"
                   value={until}
                   onChange={(e) => setUntil(e.target.value)}
@@ -190,4 +190,3 @@ export default function OrderImportButton() {
     </>
   )
 }
-

--- a/frontend/src/components/orders/OrderItemsPanel.tsx
+++ b/frontend/src/components/orders/OrderItemsPanel.tsx
@@ -7,7 +7,7 @@
  * Match action uses an Autocomplete that searches variants by product
  * name or SKU via GET /variants/search?q=...
  */
-import { useState, type MouseEvent } from 'react'
+import { useState, type MouseEvent, type ReactNode } from 'react'
 import {
   Box,
   Typography,
@@ -48,9 +48,10 @@ import type {
 
 interface OrderItemsPanelProps {
   orderId: number
+  headerAction?: ReactNode
 }
 
-export default function OrderItemsPanel({ orderId }: OrderItemsPanelProps) {
+export default function OrderItemsPanel({ orderId, headerAction }: OrderItemsPanelProps) {
   const queryClient = useQueryClient()
 
   const { data: order, isLoading, error } = useQuery<OrderDetail>({
@@ -89,20 +90,72 @@ export default function OrderItemsPanel({ orderId }: OrderItemsPanelProps) {
   }
 
   return (
-    <Box sx={{ py: 1, px: 2 }}>
-      {/* Mini header with order info */}
-      <Stack direction="row" spacing={2} alignItems="center" sx={{ mb: 1 }}>
-        <Typography variant="subtitle2" color="text.secondary">
-          {order.customer_name || 'No customer'} — {order.items.length} item(s)
-        </Typography>
-        {order.customer_email && (
-          <Typography variant="caption" color="text.secondary">
-            {order.customer_email}
+    <Box sx={{ p: 1.5, bgcolor: 'action.hover' }}>
+      <Stack
+        direction="row"
+        spacing={2}
+        alignItems="center"
+        sx={{ mb: 1.25, flexWrap: 'nowrap', overflow: 'hidden' }}
+      >
+        <Box sx={{ minWidth: 160, maxWidth: 260, flexShrink: 1, overflow: 'hidden' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+            Customer
           </Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.82rem', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {order.customer_name || 'No customer'}
+          </Typography>
+        </Box>
+        <Box sx={{ minWidth: 180, maxWidth: 300, flexShrink: 1, overflow: 'hidden' }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+            Email
+          </Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.82rem', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {order.customer_email || '-'}
+          </Typography>
+        </Box>
+        <Box sx={{ minWidth: 120, maxWidth: 180, flexShrink: 0 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+            External ID
+          </Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.82rem' }}>
+            {order.external_order_number || order.external_order_id}
+          </Typography>
+        </Box>
+        <Box sx={{ minWidth: 80, flexShrink: 0 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+            Items
+          </Typography>
+          <Typography variant="body2" sx={{ fontSize: '0.82rem' }}>
+            {order.items.length}
+          </Typography>
+        </Box>
+        {headerAction && (
+          <Box sx={{ marginLeft: 'auto', flexShrink: 0 }}>
+            {headerAction}
+          </Box>
         )}
       </Stack>
-
-      <Table size="small" sx={{ backgroundColor: 'action.hover', borderRadius: 1 }}>
+      <Box sx={{ mb: 1.25 }}>
+        <Typography variant="caption" color="text.secondary" sx={{ display: 'block' }}>
+          Shipping Address
+        </Typography>
+        <Typography variant="body2" sx={{ fontSize: '0.82rem' }}>
+          {[
+            order.shipping_address_line1,
+            order.shipping_address_line2,
+            order.shipping_city,
+            order.shipping_state,
+            order.shipping_postal_code,
+            order.shipping_country,
+          ]
+            .filter(Boolean)
+            .join(', ') || '—'}
+        </Typography>
+      </Box>
+      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+        Line Items
+      </Typography>
+      <Table size="small">
         <TableHead>
           <TableRow>
             <TableCell>Item Name</TableCell>
@@ -119,6 +172,18 @@ export default function OrderItemsPanel({ orderId }: OrderItemsPanelProps) {
           {order.items.map((item: OrderItemDetail) => (
             <ItemRow key={item.id} item={item} onAction={invalidate} />
           ))}
+          <TableRow>
+            <TableCell colSpan={3} />
+            <TableCell align="right" sx={{ fontWeight: 600 }}>
+              Line Total
+            </TableCell>
+            <TableCell align="right" sx={{ fontWeight: 600 }}>
+              {order.items
+                .reduce((sum, item) => sum + Number(item.total_price || 0), 0)
+                .toFixed(2)}
+            </TableCell>
+            <TableCell colSpan={3} />
+          </TableRow>
         </TableBody>
       </Table>
     </Box>

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_SEATALK_APP_ID?: string
   readonly VITE_SEATALK_REDIRECT_URI?: string
+  readonly VITE_DISABLE_PRODUCT_IMAGES?: string
 }
 
 interface ImportMeta {

--- a/frontend/src/pages/InventoryManagement.tsx
+++ b/frontend/src/pages/InventoryManagement.tsx
@@ -72,6 +72,7 @@ interface ExpandedRowProps {
   onSyncVariant: (variant: EnhancedVariant) => void
   syncingVariantId: number | null
   syncDisabled: boolean
+  imagesEnabled: boolean
   onManageImages: (sku: string) => void
   canAdmin: boolean
   onOpenHoldPrompt: (variant: EnhancedVariant) => void
@@ -150,6 +151,7 @@ function ExpandedRow({
   onSyncVariant,
   syncingVariantId,
   syncDisabled,
+  imagesEnabled,
   onManageImages,
   canAdmin,
   onOpenHoldPrompt,
@@ -254,6 +256,7 @@ function ExpandedRow({
                         variant="outlined"
                         startIcon={<PhotoLibrary fontSize="small" />}
                         onClick={() => onManageImages(variant.full_sku)}
+                        sx={{ display: imagesEnabled ? 'inline-flex' : 'none' }}
                       >
                         Manage Images
                       </Button>
@@ -292,6 +295,8 @@ function ExpandedRow({
 }
 
 export default function InventoryManagement() {
+  const disableProductImages = import.meta.env.VITE_DISABLE_PRODUCT_IMAGES === 'true'
+  const includeImagesInZohoSync = !disableProductImages
   const [viewMode, setViewMode] = useState<ViewMode>('list')
   const [searchInput, setSearchInput] = useState('')
   const debouncedSearch = useDebouncedValue(searchInput, 200)
@@ -493,7 +498,7 @@ export default function InventoryManagement() {
   const zohoSingleSyncMutation = useMutation({
     mutationFn: async (variant: EnhancedVariant) => {
       const response = await axiosClient.post(ZOHO.SYNC_SINGLE_ITEM(variant.id), {
-        include_images: true,
+        include_images: includeImagesInZohoSync,
         include_composites: true,
         force_resync: true,
       })
@@ -516,7 +521,7 @@ export default function InventoryManagement() {
   })
 
   const handleStartZohoSync = async () => {
-    await zohoBulkSyncMutation.mutateAsync({ includeImages: true, limit: 5000 })
+    await zohoBulkSyncMutation.mutateAsync({ includeImages: includeImagesInZohoSync, limit: 5000 })
   }
 
   const handleStartZohoSyncNoImages = async () => {
@@ -524,7 +529,7 @@ export default function InventoryManagement() {
   }
 
   const handleStartZohoBundleSync = async () => {
-    await zohoBulkSyncMutation.mutateAsync({ includeImages: true, limit: 5000, bundleOnly: true })
+    await zohoBulkSyncMutation.mutateAsync({ includeImages: includeImagesInZohoSync, limit: 5000, bundleOnly: true })
   }
 
   const handleSyncSingleVariant = async (variant: EnhancedVariant) => {
@@ -841,7 +846,7 @@ export default function InventoryManagement() {
                 }}
                 disabled={zohoBulkSyncMutation.isPending || isZohoSyncRunning}
               >
-                Sync All to Zoho
+                {includeImagesInZohoSync ? 'Sync All to Zoho' : 'Sync All to Zoho (Dev: No Images)'}
               </MenuItem>
               <MenuItem
                 onClick={() => {
@@ -1180,6 +1185,7 @@ export default function InventoryManagement() {
                             variant="outlined"
                             startIcon={<PhotoLibrary fontSize="small" />}
                             onClick={() => setManageImagesSku(variant.full_sku)}
+                            sx={{ display: disableProductImages ? 'none' : 'inline-flex' }}
                           >
                             Manage Images
                           </Button>
@@ -1259,6 +1265,7 @@ export default function InventoryManagement() {
                           onSyncVariant={(variant) => void handleSyncSingleVariant(variant)}
                           syncingVariantId={syncingVariantId}
                           syncDisabled={isZohoSyncRunning || zohoSingleSyncMutation.isPending}
+                          imagesEnabled={!disableProductImages}
                           onManageImages={(sku) => setManageImagesSku(sku)}
                           canAdmin={canAdmin}
                           onOpenHoldPrompt={openHoldPrompt}

--- a/frontend/src/pages/OrdersManagement.tsx
+++ b/frontend/src/pages/OrdersManagement.tsx
@@ -12,9 +12,6 @@ import {
   Box,
   Typography,
   Paper,
-  Grid,
-  Card,
-  CardContent,
   Chip,
   Table,
   TableBody,
@@ -46,6 +43,7 @@ import {
   KeyboardArrowDown,
   KeyboardArrowUp,
   CloudSync,
+  FilterList,
 } from '@mui/icons-material'
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
 
@@ -66,6 +64,7 @@ import OrderSyncButton from '../components/orders/OrderSyncButton'
 import AdminDateRangeSync from '../components/orders/AdminDateRangeSync'
 import OrderImportButton from '../components/orders/OrderImportButton'
 import OrderItemsPanel from '../components/orders/OrderItemsPanel'
+import OrderSummaryCards from '../components/common/OrderSummaryCards'
 import { useAuth } from '../hooks/useAuth'
 import SearchField from '../components/common/SearchField'
 import { useDebouncedValue } from '../hooks/useDebouncedValue'
@@ -151,6 +150,7 @@ export default function OrdersManagement() {
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
   const [searchInput, setSearchInput] = useState('')
   const debouncedSearch = useDebouncedValue(searchInput, 250)
+  const [filtersDialogOpen, setFiltersDialogOpen] = useState(false)
 
   // Expanded order rows
   const [expandedOrderId, setExpandedOrderId] = useState<number | null>(null)
@@ -222,6 +222,54 @@ export default function OrdersManagement() {
         sort_dir: sortDir,
         search: debouncedSearch || undefined,
       }),
+  })
+
+  const { data: orderSummary } = useQuery({
+    queryKey: [
+      'orders-summary',
+      platformFilter,
+      statusFilter,
+      itemStatusFilter,
+      zohoSyncFilter,
+      sourceFilter,
+      orderedFromFilter,
+      orderedToFilter,
+      debouncedSearch,
+    ],
+    queryFn: async () => {
+      const params = {
+        platform: platformFilter || undefined,
+        status: statusFilter || undefined,
+        item_status: itemStatusFilter || undefined,
+        zoho_sync_status: zohoSyncFilter || undefined,
+        source: sourceFilter || undefined,
+        ordered_at_from: orderedFromFilter ? new Date(`${orderedFromFilter}T00:00:00`).toISOString() : undefined,
+        ordered_at_to: orderedToFilter ? new Date(`${orderedToFilter}T23:59:59.999`).toISOString() : undefined,
+        search: debouncedSearch || undefined,
+      } as const
+
+      const pageSize = 500
+      let skip = 0
+      let totalOrders = 0
+      let unmatchedOrders = 0
+      let unmatchedItems = 0
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const batch = await listOrders({ ...params, skip, limit: pageSize })
+        if (skip === 0) {
+          totalOrders = batch.total
+        }
+        unmatchedOrders += batch.items.filter((order) => order.unmatched_count > 0).length
+        unmatchedItems += batch.items.reduce((sum, order) => sum + order.unmatched_count, 0)
+        if (batch.items.length < pageSize) {
+          break
+        }
+        skip += pageSize
+      }
+
+      return { totalOrders, unmatchedOrders, unmatchedItems }
+    },
   })
 
   // ── Handlers ─────────────────────────────────────────────────────
@@ -468,7 +516,19 @@ export default function OrdersManagement() {
       && new Date(`${bulkFromDate}T00:00:00`) > new Date(`${bulkToDate}T23:59:59.999`),
   )
   const canStartBulkSync = Boolean(bulkFromDate && bulkToDate && !invalidBulkRange)
-  const columnCount = hasRole(['ADMIN']) ? 11 : 10
+  const columnCount = 10
+  const activeFilterCount = [
+    platformFilter !== '',
+    statusFilter !== '',
+    itemStatusFilter !== '',
+    zohoSyncFilter !== '',
+    sourceFilter !== '',
+    !!orderedFromFilter,
+    !!orderedToFilter,
+    sortBy !== 'ordered_at',
+    sortDir !== 'desc',
+  ].filter(Boolean).length
+  const hasActiveFilters = activeFilterCount > 0 || !!searchInput
 
   const handleShippingStatusChange = (
     orderId: number,
@@ -520,76 +580,37 @@ export default function OrdersManagement() {
         </Stack>
       </Box>
 
-      {/* Summary Cards */}
+      <OrderSummaryCards
+        totalOrders={orderSummary?.totalOrders ?? ordersData?.total ?? 0}
+        unmatchedOrders={orderSummary?.unmatchedOrders ?? 0}
+        unmatchedItems={orderSummary?.unmatchedItems ?? 0}
+      />
       {syncStatus && (
-        <Grid container spacing={2} sx={{ mb: 3 }}>
-          <Grid item xs={6} sm={3}>
-            <Card>
-              <CardContent sx={{ py: 1.5 }}>
-                <Typography color="text.secondary" variant="body2">
-                  Total Orders
-                </Typography>
-                <Typography variant="h5">{syncStatus.total_orders}</Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid item xs={6} sm={3}>
-            <Card>
-              <CardContent sx={{ py: 1.5 }}>
-                <Typography color="text.secondary" variant="body2">
-                  Unmatched Items
-                </Typography>
-                <Typography variant="h5" color="error.main">
-                  {syncStatus.total_unmatched_items}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid item xs={6} sm={3}>
-            <Card>
-              <CardContent sx={{ py: 1.5 }}>
-                <Typography color="text.secondary" variant="body2">
-                  Matched Items
-                </Typography>
-                <Typography variant="h5" color="info.main">
-                  {syncStatus.total_matched_items}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid item xs={6} sm={3}>
-            <Card>
-              <CardContent sx={{ py: 1.5 }}>
-                <Typography color="text.secondary" variant="body2">
-                  Platforms
-                </Typography>
-                <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                  {syncStatus.platforms.map((p) => (
-                    <Chip
-                      key={p.platform_name}
-                      label={p.platform_name}
-                      size="small"
-                      color={
-                        p.current_status === 'SYNCING'
-                          ? 'primary'
-                          : p.current_status === 'ERROR'
-                            ? 'error'
-                            : 'default'
-                      }
-                      variant="outlined"
-                    />
-                  ))}
-                </Stack>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
+        <Paper sx={{ p: 1.5, mb: 2 }}>
+          <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+            {syncStatus.platforms.map((p) => (
+              <Chip
+                key={p.platform_name}
+                label={p.platform_name}
+                size="small"
+                color={
+                  p.current_status === 'SYNCING'
+                    ? 'primary'
+                    : p.current_status === 'ERROR'
+                      ? 'error'
+                      : 'default'
+                }
+                variant="outlined"
+              />
+            ))}
+          </Stack>
+        </Paper>
       )}
 
-      {/* Filters */}
+      {/* Search + Filters */}
       <Paper sx={{ p: 2, mb: 2 }}>
-        <Grid container spacing={2} alignItems="center">
-          <Grid item xs={12} md={2.5}>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={1.5} alignItems={{ xs: 'stretch', md: 'center' }}>
+          <Box sx={{ minWidth: 280, flex: 1 }}>
             <SearchField
               fullWidth
               size="small"
@@ -600,170 +621,18 @@ export default function OrdersManagement() {
                 setPage(0)
               }}
             />
-          </Grid>
-          <Grid item xs={6} md={2}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Platform</InputLabel>
-              <Select
-                value={platformFilter}
-                onChange={(e) => {
-                  setPlatformFilter(e.target.value as OrderPlatform | '')
-                  setPage(0)
-                }}
-                label="Platform"
-              >
-                <MenuItem value="">All</MenuItem>
-                {(Object.keys(PLATFORM_LABELS) as OrderPlatform[]).map((p) => (
-                  <MenuItem key={p} value={p}>
-                    {PLATFORM_LABELS[p]}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={6} md={2}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Order Status</InputLabel>
-              <Select
-                value={statusFilter}
-                onChange={(e) => {
-                  setStatusFilter(e.target.value as OrderStatus | '')
-                  setPage(0)
-                }}
-                label="Order Status"
-              >
-                <MenuItem value="">All</MenuItem>
-                {ORDER_STATUS_OPTIONS.map((s) => (
-                  <MenuItem key={s} value={s}>
-                    {s.replace(/_/g, ' ')}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={6} md={2}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Item Status</InputLabel>
-              <Select
-                value={itemStatusFilter}
-                onChange={(e) => {
-                  setItemStatusFilter(e.target.value as OrderItemStatus | '')
-                  setPage(0)
-                }}
-                label="Item Status"
-              >
-                <MenuItem value="">All</MenuItem>
-                {ITEM_STATUS_OPTIONS.map((s) => (
-                  <MenuItem key={s} value={s}>
-                    {s}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={6} md={1.5}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Zoho Sync</InputLabel>
-              <Select
-                value={zohoSyncFilter}
-                onChange={(e) => {
-                  setZohoSyncFilter(e.target.value as ZohoSyncStatus | '')
-                  setPage(0)
-                }}
-                label="Zoho Sync"
-              >
-                <MenuItem value="">All</MenuItem>
-                <MenuItem value="PENDING">PENDING</MenuItem>
-                <MenuItem value="DIRTY">DIRTY</MenuItem>
-                <MenuItem value="SYNCED">SYNCED</MenuItem>
-                <MenuItem value="ERROR">ERROR</MenuItem>
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={6} md={2}>
-            <TextField
-              fullWidth
-              size="small"
-              label="Source"
-              placeholder="e.g. EBAY_USAV_API"
-              value={sourceFilter}
-              onChange={(e) => {
-                setSourceFilter(e.target.value)
-                setPage(0)
-              }}
-            />
-          </Grid>
-          <Grid item xs={6} md={1.5}>
-            <TextField
-              fullWidth
-              size="small"
-              type="date"
-              label="Ordered From"
-              value={orderedFromFilter}
-              onChange={(e) => {
-                setOrderedFromFilter(e.target.value)
-                setPage(0)
-              }}
-              InputLabelProps={{ shrink: true }}
-            />
-          </Grid>
-          <Grid item xs={6} md={1.5}>
-            <TextField
-              fullWidth
-              size="small"
-              type="date"
-              label="Ordered To"
-              value={orderedToFilter}
-              onChange={(e) => {
-                setOrderedToFilter(e.target.value)
-                setPage(0)
-              }}
-              InputLabelProps={{ shrink: true }}
-            />
-          </Grid>
-          <Grid item xs={6} md={1.5}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Sort By</InputLabel>
-              <Select
-                value={sortBy}
-                onChange={(e) => {
-                  setSortBy(e.target.value as (typeof SORT_BY_OPTIONS)[number]['value'])
-                  setPage(0)
-                }}
-                label="Sort By"
-              >
-                {SORT_BY_OPTIONS.map((opt) => (
-                  <MenuItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={6} md={1.5}>
-            <FormControl fullWidth size="small">
-              <InputLabel>Sort Dir</InputLabel>
-              <Select
-                value={sortDir}
-                onChange={(e) => {
-                  setSortDir(e.target.value as 'asc' | 'desc')
-                  setPage(0)
-                }}
-                label="Sort Dir"
-              >
-                <MenuItem value="desc">Desc</MenuItem>
-                <MenuItem value="asc">Asc</MenuItem>
-              </Select>
-            </FormControl>
-          </Grid>
-          <Grid item xs={6} md={1}>
-            <Tooltip title="Reset filters">
-              <IconButton onClick={resetFilters} size="small">
-                <Refresh fontSize="small" />
-              </IconButton>
-            </Tooltip>
-          </Grid>
-        </Grid>
+          </Box>
+          <Button
+            variant={activeFilterCount > 0 ? 'contained' : 'outlined'}
+            startIcon={<FilterList />}
+            onClick={() => setFiltersDialogOpen(true)}
+          >
+            Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ''}
+          </Button>
+          <Button size="small" onClick={resetFilters} disabled={!hasActiveFilters}>
+            Clear
+          </Button>
+        </Stack>
       </Paper>
 
       {/* Orders Table */}
@@ -782,7 +651,6 @@ export default function OrdersManagement() {
                 <TableCell>Shipping Status</TableCell>
                 <TableCell>Zoho Sync</TableCell>
                 <TableCell>Ordered</TableCell>
-                {hasRole(['ADMIN']) && <TableCell align="center">Zoho</TableCell>}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -885,32 +753,27 @@ export default function OrdersManagement() {
                               : '—'}
                           </Typography>
                         </TableCell>
-                        {hasRole(['ADMIN']) && (
-                          <TableCell align="center">
-                            <Tooltip title="Sync this order to Zoho">
-                              <span>
-                                <IconButton
-                                  size="small"
-                                  color="primary"
-                                  onClick={(e) => handleForceSync(order.id, e)}
-                                  disabled={syncingOrderId === order.id}
-                                >
-                                  {syncingOrderId === order.id ? (
-                                    <CircularProgress size={18} />
-                                  ) : (
-                                    <CloudSync fontSize="small" />
-                                  )}
-                                </IconButton>
-                              </span>
-                            </Tooltip>
-                          </TableCell>
-                        )}
                       </LongPressTableRow>
                       {/* Expandable items panel */}
                       <TableRow>
                         <TableCell sx={{ py: 0 }} colSpan={columnCount}>
                           <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-                            <OrderItemsPanel orderId={order.id} />
+                            <OrderItemsPanel
+                              orderId={order.id}
+                              headerAction={
+                                hasRole(['ADMIN']) ? (
+                                  <Button
+                                    size="small"
+                                    variant="outlined"
+                                    startIcon={syncingOrderId === order.id ? <CircularProgress size={14} /> : <CloudSync />}
+                                    disabled={syncingOrderId === order.id}
+                                    onClick={(e) => handleForceSync(order.id, e)}
+                                  >
+                                    Zoho Sync
+                                  </Button>
+                                ) : undefined
+                              }
+                            />
                           </Collapse>
                         </TableCell>
                       </TableRow>
@@ -1027,6 +890,154 @@ export default function OrdersManagement() {
           <Button onClick={handleBulkSync} variant="contained" disabled={bulkLoading || !canStartBulkSync}>
             {bulkLoading ? 'Syncing…' : 'Start sync'}
           </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog open={filtersDialogOpen} onClose={() => setFiltersDialogOpen(false)} fullWidth maxWidth="sm">
+        <DialogTitle>Order Filters</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Sort By</InputLabel>
+              <Select
+                value={sortBy}
+                onChange={(e) => {
+                  setSortBy(e.target.value as (typeof SORT_BY_OPTIONS)[number]['value'])
+                  setPage(0)
+                }}
+                label="Sort By"
+              >
+                {SORT_BY_OPTIONS.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Sort Direction</InputLabel>
+              <Select
+                value={sortDir}
+                onChange={(e) => {
+                  setSortDir(e.target.value as 'asc' | 'desc')
+                  setPage(0)
+                }}
+                label="Sort Direction"
+              >
+                <MenuItem value="desc">Newest first</MenuItem>
+                <MenuItem value="asc">Oldest first</MenuItem>
+              </Select>
+            </FormControl>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Platform</InputLabel>
+              <Select
+                value={platformFilter}
+                onChange={(e) => {
+                  setPlatformFilter(e.target.value as OrderPlatform | '')
+                  setPage(0)
+                }}
+                label="Platform"
+              >
+                <MenuItem value="">All</MenuItem>
+                {(Object.keys(PLATFORM_LABELS) as OrderPlatform[]).map((p) => (
+                  <MenuItem key={p} value={p}>
+                    {PLATFORM_LABELS[p]}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Order Status</InputLabel>
+              <Select
+                value={statusFilter}
+                onChange={(e) => {
+                  setStatusFilter(e.target.value as OrderStatus | '')
+                  setPage(0)
+                }}
+                label="Order Status"
+              >
+                <MenuItem value="">All</MenuItem>
+                {ORDER_STATUS_OPTIONS.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {s.replace(/_/g, ' ')}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Item Status</InputLabel>
+              <Select
+                value={itemStatusFilter}
+                onChange={(e) => {
+                  setItemStatusFilter(e.target.value as OrderItemStatus | '')
+                  setPage(0)
+                }}
+                label="Item Status"
+              >
+                <MenuItem value="">All</MenuItem>
+                {ITEM_STATUS_OPTIONS.map((s) => (
+                  <MenuItem key={s} value={s}>
+                    {s}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <FormControl size="small" fullWidth>
+              <InputLabel>Zoho Sync</InputLabel>
+              <Select
+                value={zohoSyncFilter}
+                onChange={(e) => {
+                  setZohoSyncFilter(e.target.value as ZohoSyncStatus | '')
+                  setPage(0)
+                }}
+                label="Zoho Sync"
+              >
+                <MenuItem value="">All</MenuItem>
+                <MenuItem value="PENDING">PENDING</MenuItem>
+                <MenuItem value="DIRTY">DIRTY</MenuItem>
+                <MenuItem value="SYNCED">SYNCED</MenuItem>
+                <MenuItem value="ERROR">ERROR</MenuItem>
+              </Select>
+            </FormControl>
+            <TextField
+              fullWidth
+              size="small"
+              label="Source"
+              placeholder="e.g. EBAY_USAV_API"
+              value={sourceFilter}
+              onChange={(e) => {
+                setSourceFilter(e.target.value)
+                setPage(0)
+              }}
+            />
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Ordered From"
+              value={orderedFromFilter}
+              onChange={(e) => {
+                setOrderedFromFilter(e.target.value)
+                setPage(0)
+              }}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              fullWidth
+              size="small"
+              type="date"
+              label="Ordered To"
+              value={orderedToFilter}
+              onChange={(e) => {
+                setOrderedToFilter(e.target.value)
+                setPage(0)
+              }}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setFiltersDialogOpen(false)}>Close</Button>
         </DialogActions>
       </Dialog>
 

--- a/frontend/src/pages/OrdersManagement.tsx
+++ b/frontend/src/pages/OrdersManagement.tsx
@@ -43,7 +43,6 @@ import {
 } from '@mui/material'
 import {
   Refresh,
-  Warning,
   KeyboardArrowDown,
   KeyboardArrowUp,
   CloudSync,
@@ -586,21 +585,6 @@ export default function OrdersManagement() {
           </Grid>
         </Grid>
       )}
-
-      {/* Platform error alerts */}
-      {syncStatus?.platforms
-        .filter((p) => p.current_status === 'ERROR')
-        .map((p) => (
-          <Alert
-            key={p.platform_name}
-            severity="warning"
-            icon={<Warning />}
-            sx={{ mb: 1 }}
-          >
-            <strong>{p.platform_name}</strong> sync is in ERROR state.{' '}
-            {p.last_error_message && <em>{p.last_error_message}</em>}
-          </Alert>
-        ))}
 
       {/* Filters */}
       <Paper sx={{ p: 2, mb: 2 }}>

--- a/frontend/src/pages/PurchasingManagement.tsx
+++ b/frontend/src/pages/PurchasingManagement.tsx
@@ -75,6 +75,7 @@ import VariantSearchAutocomplete from '../components/common/VariantSearchAutocom
 import HoldActionPromptDialog from '../components/common/HoldActionPromptDialog'
 import LongPressTableRow from '../components/common/LongPressTableRow'
 import TablePaginationWithPageJump from '../components/common/TablePaginationWithPageJump'
+import OrderSummaryCards from '../components/common/OrderSummaryCards'
 import type { VariantSearchResult } from '../types/orders'
 
 const statusColor = {
@@ -652,6 +653,62 @@ export default function PurchasingManagement() {
       }),
   })
 
+  const { data: purchaseSummary } = useQuery({
+    queryKey: [
+      'purchases-summary',
+      sortBy,
+      sortDir,
+      deliverStatusFilter,
+      itemMatchFilter,
+      zohoSyncFilter,
+      sourceFilter,
+      poNumberSearch,
+      orderDateFrom,
+      orderDateTo,
+    ],
+    queryFn: async () => {
+      const pageSize = 500
+      let skip = 0
+      let totalOrders = 0
+      let unmatchedOrders = 0
+      let unmatchedItems = 0
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const batch = await listPurchaseOrdersPaged({
+          skip,
+          limit: pageSize,
+          sortBy,
+          sortDir,
+          poNumber: poNumberSearch || undefined,
+          deliverStatus: deliverStatusFilter === 'ALL' ? undefined : deliverStatusFilter,
+          itemMatchStatus:
+            itemMatchFilter === 'ALL' ? undefined : itemMatchFilter === 'MATCHED' ? 'matched' : 'unmatched',
+          zohoSyncStatus: zohoSyncFilter === 'ALL' ? undefined : zohoSyncFilter,
+          source: sourceFilter === 'ALL' ? undefined : sourceFilter,
+          orderDateFrom: orderDateFrom || undefined,
+          orderDateTo: orderDateTo || undefined,
+        })
+
+        totalOrders += batch.length
+        for (const po of batch) {
+          const poUnmatchedItems = (po.items || []).filter((item) => item.status === 'UNMATCHED').length
+          unmatchedItems += poUnmatchedItems
+          if (poUnmatchedItems > 0) {
+            unmatchedOrders += 1
+          }
+        }
+
+        if (batch.length < pageSize) {
+          break
+        }
+        skip += pageSize
+      }
+
+      return { totalOrders, unmatchedOrders, unmatchedItems }
+    },
+  })
+
   const hasNextPage = pagedOrders.length > rowsPerPage
   const orders = hasNextPage ? pagedOrders.slice(0, rowsPerPage) : pagedOrders
   const paginationCount = page * rowsPerPage + orders.length + (hasNextPage ? 1 : 0)
@@ -970,6 +1027,12 @@ export default function PurchasingManagement() {
           </Button>
         </Stack>
       </Box>
+
+      <OrderSummaryCards
+        totalOrders={purchaseSummary?.totalOrders ?? orders.length}
+        unmatchedOrders={purchaseSummary?.unmatchedOrders ?? 0}
+        unmatchedItems={purchaseSummary?.unmatchedItems ?? 0}
+      />
 
       <Grid container spacing={2}>
         <Grid item xs={12}>

--- a/skills/karpathy-guidelines/SKILL.md
+++ b/skills/karpathy-guidelines/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: karpathy-guidelines
+description: "Apply Karpathy-style coding guardrails that reduce common LLM engineering mistakes. Use when writing, reviewing, debugging, or refactoring code: surface assumptions before acting, prefer the simplest viable change, keep edits surgical, and define verifiable success criteria before implementation."
+license: MIT
+---
+
+# Karpathy Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes, derived from [Andrej Karpathy's observations](https://x.com/karpathy/status/2015883857489522876) on LLM coding pitfalls.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.

--- a/skills/karpathy-guidelines/agents/openai.yaml
+++ b/skills/karpathy-guidelines/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Karpathy Guidelines"
+  short_description: "Apply careful coding guardrails"
+  default_prompt: "Use $karpathy-guidelines for this coding task so you surface assumptions, keep changes minimal, and verify the result."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
- feature: added sales order proper import, including available customner information from api. for amazon and other sources, shipstation csv import is implemented.
- fix: sale orders line items are matched to listings instead of  straight through sku
- feature: product listing now supports sku matches manually.
- agents: added karpathy skills
- fix: unify sales order UI with purchase order UI

- to-do: mass insert all listings from all platforms.
- to-do: ebay listing through api.